### PR TITLE
:rocket: Add Unity Chess Example

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "chess"]
+	path = chess
+	url = https://github.com/magicblock-labs/Solana-Unity-Chess

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This is a collection of example games built on Solana. The games are built using
 - [Lumberjack](./lumberjack/README.md) - A simple lumberjack game where you chop trees to earn wood. (Has a gum session key example)
 - [Idle-game](./idle-game/README.md) - An idle game using clockwork.
 - [Seven Seas](./seven-seas/README.md) - A realtime on chain sea battle game with unity client.
+- [Solana Chess](https://github.com/magicblock-labs/Solana-Unity-Chess/blob/main/README.md) - 3D Chess game built with Unity.
 - [Tiny Adventure](./tiny-adventure/README.md) - A simple adventure game moving a character left and right on chain. 
 - [Battle coins](./battle-coins/README.md) - On example game showing how to interact with SPL tokens in an anchor program. 
 - [Coin flip](./coin-flip/README.md) - Verifiable randomness using VRF by switchboard.xyz. 


### PR DESCRIPTION
# :rocket: Add Unity Chess Example

Add Unity Chess example, available at https://github.com/magicblock-labs/Solana-Unity-Chess